### PR TITLE
Fix: Obsolete method warning in 2018.4 LTS

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -112,7 +112,7 @@ namespace Zenject
 #if UNITY_2019_1_OR_NEWER
                 // TODO - Is there a way to check this using GetPrefabAssetType in 2019+?
 #else
-#if UNITY_2018_3
+#if UNITY_2018_4_OR_NEWER
                 Assert.That(PrefabUtility.GetPrefabAssetType(installer.gameObject) == PrefabAssetType.NotAPrefab,
 #else
                 Assert.That(PrefabUtility.GetPrefabType(installer.gameObject) != PrefabType.Prefab,


### PR DESCRIPTION
This fix addresses a compiler warning.
So I can make a package, which supports Unity 2018.4 LTS for the Asset Store.