### PR TITLE
Fix MemoryPools doc

### DIFF
--- a/Documentation/MemoryPools.md
+++ b/Documentation/MemoryPools.md
@@ -633,7 +633,7 @@ public class TestInstaller : MonoInstaller<TestInstaller>
     {
         Container.Bind<Bar>().AsSingle();
 
-        Container.BindFactory<Vector3, Foo, Foo.Factory>().FromMonoPoolableMemoryPool<Foo>(
+        Container.BindFactory<Vector3, Foo, Foo.Factory>().FromMonoPoolableMemoryPool(
             x => x.WithInitialSize(2).FromComponentInNewPrefab(FooPrefab).UnderTransformGroup("FooPool"));
     }
 }


### PR DESCRIPTION
Got error:
> error CS1929: 'FactoryToChoiceIdBinder<Vector3, Foo>' does not contain a definition for 'FromMonoPoolableMemoryPool' and the best extension method overload 'FactoryFromBinder0Extensions.FromMonoPoolableMemoryPool<Vector3>(FactoryFromBinder<Vector3>, Action<MemoryPoolInitialSizeMaxSizeBinder<Vector3>>)' requires a receiver of type 'FactoryFromBinder<Vector3>'

Generic params should be `FromMonoPoolableMemoryPool<Vector3, Foo>`. But in this case we can completely remove them.