### PR TITLE
Tests: Fix tests building errors

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Zenject-IntegrationTests-Editor.asmdef
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Zenject-IntegrationTests-Editor.asmdef
@@ -3,12 +3,21 @@
     "references": [
         "Zenject-TestFramework",
         "Zenject",
-        "Zenject-IntegrationTests"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Zenject-IntegrationTests",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "Zenject-usage.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": []
 }

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Zenject-UnitTests-Editor.asmdef
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Zenject-UnitTests-Editor.asmdef
@@ -2,14 +2,23 @@
     "name": "Zenject-UnitTests-Editor",
     "references": [
         "Zenject",
-        "Zenject-TestFramework"
-    ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
+        "Zenject-TestFramework",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
     "includePlatforms": [
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": false
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "Zenject-usage.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": []
 }


### PR DESCRIPTION
When I checkout the project and open in unity I get flooded with 365 errors like this:

```cs
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Other/ZenjectProfileTest.cs(53,14): error CS0246: The type or namespace name 'InjectAttribute' could not be found (are you missing a using directive or an assembly reference?)
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Other/ZenjectProfileTest.cs(53,14): error CS0246: The type or namespace name 'Inject' could not be found (are you missing a using directive or an assembly reference?)
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/MemoryPool/TestPoolableStaticMemoryPool.cs(36,28): error CS0246: The type or namespace name 'IPoolable<>' could not be found (are you missing a using directive or an assembly reference?)
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Other/TestFacadeSubContainer.cs(61,33): error CS0246: The type or namespace name 'IInitializable' could not be found (are you missing a using directive or an assembly reference?)
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Other/TestValidation.cs(172,14): error CS0246: The type or namespace name 'InjectAttribute' could not be found (are you missing a using directive or an assembly reference?)
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Other/TestValidation.cs(172,14): error CS0246: The type or namespace name 'Inject' could not be found (are you missing a using directive or an assembly reference?)
Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Other/TestFacadeSubContainer.cs(71,33): error CS0246: The type or namespace name 'ITickable' could not be found (are you missing a using directive or an assembly reference?)
```

You can see a live build here:
https://github.com/paulpach/Extenject/runs/401567986

The issue is that the test assembly definitions are missing a reference to Zenject-usage.dll  This PR fixes that problem.