### PR TITLE
CI/CD pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,9 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: Zenject-usage
+
+      - name: Install Zenject-usage
+        run: cp AssemblyBuild\Zenject-usage\bin\Debug\Zenject-usage.dll UnityProject/Assets/Plugins/Zenject/Source/Usage
         
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   Zenject-usage:
     runs-on: [windows]
+    name: Zenject-usage
     steps:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ on:
       - '*.md'
   
 jobs:
-  Zenject-usage:
-    runs-on: [windows]
-    name: Zenject-usage
+  ZenjectUsage:
+    runs-on: windows
+    name: ZenjectUsage
     steps:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
@@ -29,7 +29,7 @@ jobs:
   buildUnity:
     name: Unity test
     runs-on: ubuntu-latest
-    needs: Zenject-usage
+    needs: ZenjectUsage
     env:
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
 #        with:
 #          python-version: "3.8"
 
-      - name: Install filter-repo
-        run: pip3 install git-filter-repo
+#      - name: Install filter-repo
+#        run: pip3 install git-filter-repo
 
       - name: Activate license
         uses: MirrorNG/unity-runner@master
@@ -40,7 +40,7 @@ jobs:
       - name: Run editor Tests
         uses: MirrorNG/unity-runner@master
         with:
-          args: -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests
+          args: -projectPath UnityProject -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests
         
       # Upload artifacts
       - name: Publish test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: "3.8"
+#      - name: Set up Python ${{ matrix.python-version }}
+#        uses: actions/setup-python@v1
+#        with:
+#          python-version: "3.8"
 
       - name: Install filter-repo
         run: pip3 install git-filter-repo
@@ -49,11 +49,11 @@ jobs:
           name: Test results (editor mode)
           path: Tests/editmode-results.xml
 
-      - name: Generate Solution
-        uses: MirrorNG/unity-runner@master
-        with:
-          # Arguments to pass to unity
-          args: -buildTarget StandaloneWindows64 -customBuildName MirrorNG -customBuildPath ./build/StandaloneWindows64 -projectPath . -executeMethod  UnityEditor.SyncVS.SyncSolution -quit
+#      - name: Generate Solution
+#        uses: MirrorNG/unity-runner@master
+#        with:
+#          # Arguments to pass to unity
+#          args: -buildTarget StandaloneWindows64 -customBuildName MirrorNG -customBuildPath ./build/StandaloneWindows64 -projectPath . -executeMethod  UnityEditor.SyncVS.SyncSolution -quit
   
 #      - name: SonarQube analysis
 #        uses: MirrorNG/unity-sonarscanner@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,34 @@ on:
       - '*.md'
   
 jobs:
+   
+  #enable this job to request a manual unity license
+  Request-License:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Request manual activation file
+        uses: MirrorNG/unity-runner@master
+        with:
+            entrypoint: /request_activation.sh
+
+      # This will produce a Unity_xxx.alf file
+      # download it in your computer and upload it to
+      # https://license.unity3d.com/manual
+      # That will produce a Unity_xxx.ulf file
+      # add the contents of Unity_xxx.ulf file to your repository's secrets
+      # as UNITY_LICENSE
+      # then disable this job
+      - name: Expose as artifact
+        uses: actions/upload-artifact@v1
+        with:
+            name: Manual Activation File
+            path: ${{ steps.getManualLicenseFile.outputs.filePath }}
+  
+        
   Zenject-usage:
     runs-on: [windows-latest]
     name: Zenject-usage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 on: 
   push:
     paths-ignore:
-      - 'doc/**'
+      - 'Documentation/**'
       - '*.md'
   
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: Test results (editor mode)
-          path: Tests/editmode-results.xml
+          path: UnityProject/Tests/editmode-results.xml
 
 #      - name: Generate Solution
 #        uses: MirrorNG/unity-runner@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,11 +20,11 @@ jobs:
         working-directory: AssemblyBuild\Zenject-usage
         run: msbuild Zenject-usage.sln
         
-      - name: Upload dll
-        uses: actions/upload-artifact@v1
-        with:
-          name: Zenject-usage.dll
-          path: AssemblyBuild\Zenject-usage\Zenject-usage.dll
+#      - name: Upload dll
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: Zenject-usage.dll
+#          path: AssemblyBuild\Zenject-usage\Zenject-usage.dll
         
   buildUnity:
     name: Unity test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download math result for job 1
+      - name: Download Zenject-usage
         uses: actions/download-artifact@v1
         with:
           name: Zenject-usage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,27 +9,27 @@ on:
       - '*.md'
   
 jobs:
-#  ZenjectUsage:
-#    runs-on: windows
-#    name: ZenjectUsage
-#    steps:
-#      - name: Setup MSBuild.exe
-#        uses: warrenbuckley/Setup-MSBuild@v1
+  ZenjectUsage:
+    runs-on: windows
+    name: ZenjectUsage
+    steps:
+      - name: Setup MSBuild.exe
+        uses: warrenbuckley/Setup-MSBuild@v1
         
-#      - name: MSBuild
-#        working-directory: AssemblyBuild\Zenject-usage
-#        run: msbuild Zenject-usage.sln
+      - name: MSBuild
+        working-directory: AssemblyBuild\Zenject-usage
+        run: msbuild Zenject-usage.sln
         
-#      - name: Upload dll
-#        uses: actions/upload-artifact@v1
-#        with:
-#          name: Zenject-usage.dll
-#          path: AssemblyBuild\Zenject-usage\Zenject-usage.dll
+      - name: Upload dll
+        uses: actions/upload-artifact@v1
+        with:
+          name: Zenject-usage.dll
+          path: AssemblyBuild\Zenject-usage\Zenject-usage.dll
         
   buildUnity:
     name: Unity test
     runs-on: ubuntu-latest
-#    needs: ZenjectUsage
+    needs: ZenjectUsage
     env:
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
     steps:
@@ -40,7 +40,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Zenject-usage
         
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
         
-      - name: MSBuild
-        working-directory: AssemblyBuild\Zenject-usage
-        run: msbuild Zenject-usage.sln
+#      - name: MSBuild
+#        working-directory: AssemblyBuild\Zenject-usage
+#        run: msbuild Zenject-usage.sln
         
 #      - name: Upload dll
 #        uses: actions/upload-artifact@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,12 @@ on:
       - '*.md'
   
 jobs:
-  ZenjectUsage:
-    runs-on: windows
-    name: ZenjectUsage
-    steps:
-      - name: Setup MSBuild.exe
-        uses: warrenbuckley/Setup-MSBuild@v1
+#  ZenjectUsage:
+#    runs-on: windows
+#    name: ZenjectUsage
+#    steps:
+#      - name: Setup MSBuild.exe
+#        uses: warrenbuckley/Setup-MSBuild@v1
         
 #      - name: MSBuild
 #        working-directory: AssemblyBuild\Zenject-usage
@@ -29,7 +29,7 @@ jobs:
   buildUnity:
     name: Unity test
     runs-on: ubuntu-latest
-    needs: ZenjectUsage
+#    needs: ZenjectUsage
     env:
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,26 @@ on:
       - '*.md'
   
 jobs:
-
-  testRunnerInAllModes:
+  Zenject-usage:
+    runs-on: [windows]
+    steps:
+      - name: Setup MSBuild.exe
+        uses: warrenbuckley/Setup-MSBuild@v1
+        
+      - name: MSBuild
+        working-directory: AssemblyBuild\Zenject-usage
+        run: msbuild Zenject-usage.sln
+        
+      - name: Upload dll
+        uses: actions/upload-artifact@v1
+        with:
+          name: Zenject-usage.dll
+          path: AssemblyBuild\Zenject-usage\Zenject-usage.dll
+        
+  buildUnity:
     name: Unity test
     runs-on: ubuntu-latest
+    needs: Zenject-usage
     env:
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
     steps:
@@ -23,6 +39,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Zenject-usage
+        
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1
 #        with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
   
 jobs:
   ZenjectUsage:
-    runs-on: windows
+    runs-on: [windows-latest]
     name: ZenjectUsage
     steps:
       - name: Setup MSBuild.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           name: Zenject-usage
 
       - name: Install Zenject-usage
-        run: cp AssemblyBuild\Zenject-usage\bin\Debug\Zenject-usage.dll UnityProject/Assets/Plugins/Zenject/Source/Usage
+        run: cp AssemblyBuild/Zenject-usage/bin/Debug/Zenject-usage.dll UnityProject/Assets/Plugins/Zenject/Source/Usage
         
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,18 +55,18 @@ jobs:
           # Arguments to pass to unity
           args: -buildTarget StandaloneWindows64 -customBuildName MirrorNG -customBuildPath ./build/StandaloneWindows64 -projectPath . -executeMethod  UnityEditor.SyncVS.SyncSolution -quit
   
-      - name: SonarQube analysis
-        uses: MirrorNG/unity-sonarscanner@master
-        with:
-          buildCommand: /opt/Unity/Editor/Data/NetCore/Sdk-2.2.107/dotnet build workspace.sln
-          projectKey: MirrorNG_MirrorNG
-          projectName: MirrorNG
-          sonarOrganisation: mirrorng
-          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml
-        env:
-          FrameworkPathOverride: /opt/Unity/Editor/Data/MonoBleedingEdge/
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: SonarQube analysis
+#        uses: MirrorNG/unity-sonarscanner@master
+#        with:
+#          buildCommand: /opt/Unity/Editor/Data/NetCore/Sdk-2.2.107/dotnet build workspace.sln
+#          projectKey: MirrorNG_MirrorNG
+#          projectName: MirrorNG
+#          sonarOrganisation: mirrorng
+#          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml
+#        env:
+#          FrameworkPathOverride: /opt/Unity/Editor/Data/MonoBleedingEdge/
+#          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,9 @@ on:
       - '*.md'
   
 jobs:
-  ZenjectUsage:
+  Zenject-usage:
     runs-on: [windows-latest]
-    name: ZenjectUsage
+    name: Zenject-usage
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
   buildUnity:
     name: Unity test
     runs-on: ubuntu-latest
-    needs: ZenjectUsage
+    needs: Zenject-usage
     env:
       UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,9 @@ jobs:
           name: Zenject-usage
 
       - name: Install Zenject-usage
-        run: cp AssemblyBuild/Zenject-usage/bin/Debug/Zenject-usage.dll UnityProject/Assets/Plugins/Zenject/Source/Usage
+        run: |
+          ls -l Zenject-usage
+          cp Zenject-usage/Zenject-usage.dll UnityProject/Assets/Plugins/Zenject/Source/Usage
         
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           ls -l Zenject-usage
           cp Zenject-usage/Zenject-usage.dll UnityProject/Assets/Plugins/Zenject/Source/Usage
+          ls -l UnityProject/Assets/Plugins/Zenject/Source/Usage
         
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on: 
+  push:
+    branches: 
+      - master
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+  
+jobs:
+
+  testRunnerInAllModes:
+    name: Unity test
+    runs-on: ubuntu-latest
+    env:
+      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+    steps:
+  
+      # Checkout repository (required to test local actions)
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.8"
+
+      - name: Install filter-repo
+        run: pip3 install git-filter-repo
+
+      - name: Activate license
+        uses: MirrorNG/unity-runner@master
+        with:
+          entrypoint: /activate.sh
+          
+      # Configure test runner
+      - name: Run editor Tests
+        uses: MirrorNG/unity-runner@master
+        with:
+          args: -runTests -testPlatform editmode -testResults Tests/editmode-results.xml -enableCodeCoverage -coverageResultsPath Tests
+        
+      # Upload artifacts
+      - name: Publish test results
+        uses: actions/upload-artifact@v1
+        with:
+          name: Test results (editor mode)
+          path: Tests/editmode-results.xml
+
+      - name: Generate Solution
+        uses: MirrorNG/unity-runner@master
+        with:
+          # Arguments to pass to unity
+          args: -buildTarget StandaloneWindows64 -customBuildName MirrorNG -customBuildPath ./build/StandaloneWindows64 -projectPath . -executeMethod  UnityEditor.SyncVS.SyncSolution -quit
+  
+      - name: SonarQube analysis
+        uses: MirrorNG/unity-sonarscanner@master
+        with:
+          buildCommand: /opt/Unity/Editor/Data/NetCore/Sdk-2.2.107/dotnet build workspace.sln
+          projectKey: MirrorNG_MirrorNG
+          projectName: MirrorNG
+          sonarOrganisation: mirrorng
+          beginArguments: /d:sonar.verbose="true" /d:sonar.cs.nunit.reportsPaths=Tests/editmode-results.xml /d:sonar.cs.opencover.reportsPaths=Tests/workspace-opencov/EditMode/TestCoverageResults_0000.xml
+        env:
+          FrameworkPathOverride: /opt/Unity/Editor/Data/MonoBleedingEdge/
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          extra_plugins: |
+            @semantic-release/exec
+            @semantic-release/changelog
+            @semantic-release/git
+          branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: CI
 
 on: 
   push:
-    branches: 
-      - master
     paths-ignore:
       - 'doc/**'
       - '*.md'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: [windows-latest]
     name: ZenjectUsage
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Setup MSBuild.exe
         uses: warrenbuckley/Setup-MSBuild@v1
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Upload dll
         uses: actions/upload-artifact@v1
         with:
-          name: Zenject-usage.dll
-          path: AssemblyBuild\Zenject-usage\Zenject-usage.dll
+          name: Zenject-usage
+          path: AssemblyBuild\Zenject-usage\bin\Debug\
         
   buildUnity:
     name: Unity test
@@ -43,6 +43,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download math result for job 1
+        uses: actions/download-artifact@v1
+        with:
+          name: Zenject-usage
         
 #      - name: Set up Python ${{ matrix.python-version }}
 #        uses: actions/setup-python@v1

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,27 @@
+{
+    "plugins": [
+        "@semantic-release/github",
+        "@semantic-release/release-notes-generator", 
+        ["@semantic-release/commit-analyzer", {
+            "preset": "angular",
+            "releaseRules": [
+                {"type": "breaking", "release": "major"},
+                {"type": "feature", "release": "minor"},
+            ]
+        }],
+        ["@semantic-release/changelog", {
+            "changelogFile": "UnityProject/Assets/Plugins/Zenject/CHANGELOG.md",
+        }],
+        ["@semantic-release/npm", {
+            "npmPublish": false,
+            "pkgRoot": "UnityProject/Assets/Plugins/Zenject"
+        }],
+        ["@semantic-release/git", {
+            "assets": ["UnityProject/Assets/Plugins/Zenject/package.json", "UnityProject/Assets/Plugins/Zenject/CHANGELOG.md"],
+            "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        }]
+#        ["@semantic-release/exec", {
+#            "publishCmd": "./publish_upm.sh upm ${nextRelease.version}"
+#        }]
+    ]
+}

--- a/UnityProject/Assets/Plugins/Zenject/package.json
+++ b/UnityProject/Assets/Plugins/Zenject/package.json
@@ -1,0 +1,8 @@
+  
+{
+	"name": "com.svermeulen.extenject",
+	"displayName": "Extenject",
+	"version": "0.0.1",
+	"description": "Dependency Injection Framework for Unity3D",
+	"dependencies": {}
+}

--- a/UnityProject/Assets/Plugins/Zenject/package.json.meta
+++ b/UnityProject/Assets/Plugins/Zenject/package.json.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5ee7f1788474bd44a48b0a201461151
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  


### PR DESCRIPTION
First version of a CI/CD pipeline.   Fixes #63 

It will built zenject and run the unit tests,  If they pass it might create a release depending on the change.

The versioning system is based on semantic release,  and it is controlled by the commit message. 

You prefix every commit with either fix, pref, feat or breaking.   For example:

"fix: describe what got fixed"
"perf: Improved performance of xxx"
"feat: New feature"
"breaking: This change is a breaking change"

When merging pull requests, I recommend renaming them to add the prefix and squashing them.

This is the first version of a CI/CD Pipeline.   
This does not include static analysis or upm release. 

Sample run here:  https://github.com/paulpach/Extenject/actions/runs/31254966

For this to work,  you will need to create a manual license.   Enable the Request-license job,  and follow the instructions I put in the comments.  
