### PR TITLE
Interface Compatibility for Signals

### DIFF
--- a/Documentation/Signals.md
+++ b/Documentation/Signals.md
@@ -11,6 +11,7 @@
     * <a href="#signalbusinstaller">SignalBusInstaller</a>
     * <a href="#when-to-use-signals">When To Use Signals</a>
 * Advanced
+    * <a href="#abstract-signals">Abstract Signals</a>
     * <a href="#use-with-subcontainers">Signals With Subcontainers</a>
     * <a href="#async-signals">Asynchronous Signals</a>
     * <a href="#settings">Signal Settings</a>
@@ -478,6 +479,152 @@ Signals are most appropriate as a communication mechanism when:
 These are just rules of thumb, but useful to keep in mind when using signals.  The less logically coupled the sender is to the response behaviour of the receivers, the more appropriate it is compared to other forms of communication such as direct method calls, interfaces, C# event class members, etc.  This is also one reason you might consider using <a href="#async-signals">asynchronous signals</a>
 
 When event driven program is abused, it is possible to find yourself in "callback hell" where events are triggering other events etc. and which make the entire system impossible to understand.  So signals in general should be used with caution.  Personally I like to use signals for high level game-wide events and then use other forms of communication (unirx streams, c# events, direct method calls, interfaces) for most other things.
+
+## <a id="abstract-signals"></a>Abstract Signals
+
+One of the problems of the signals is that when subscribe to their concrete types
+you are coupling your concrete signal types to the subscribers
+
+For example, Lets say I have a player and i want to save the game when i finish a level.
+Ok easy, I create ``SignalLevelCompleted`` and then I subscribe it to my ``SaveGameSystem``
+then I also want to save when i reach a checkpoint, again i create ``SignalCheckpointReached``
+and then I subscribe it to my ``SaveGameSystem``
+you are begining to get something like this...
+```csharp
+public class Example
+{
+   SignalBus signalBus;
+   public Example(Signalbus signalBus) => this.signalBus = signalBus;
+   
+   public void CheckpointReached() => signalBus.Fire<SignalCheckpointReached>();
+   
+   public void CompleteLevel() => signalBus.Fire<SignalLevelCompleted>();
+}
+
+public class SaveGameSystem
+{
+   public SaveGameSystem(SignalBus signalBus)
+   {
+      signalBus.Subscribe<SignalCheckpointReached>(x => SaveGame());
+      signalBus.Subscribe<SignalLevelCompleted>(x => SaveGame());
+   }
+   
+   void SaveGame() { /*Saves the game*/ }
+}
+
+//in your installer
+Container.DeclareSignal<SignalLevelCompleted>();
+Container.DeclareSignal<SignalCheckpointReached>();
+
+//your signal types
+public struct SignalCheckpointReached{}
+public struct SignalLevelCompleted{}
+```
+
+And then you realize you are coupling the types``signalLevelCompleted`` and ``SignalCheckpointReached``to ``SaveGameSystem``. 
+``SaveGameSystem`` shouldn't know about those "non related with saving" events...
+
+So let's give the power of interfaces to signals!
+So i have the ``SignalCheckpointReached`` and ``SignalLevelCompleted`` both implementing **``ISignalGameSaver``**
+and my ``SaveGameSystem`` just Subscribes to **``ISignalGameSaver``** for saving the game
+So when i fire any of those signals the ``SaveGameSystem`` saves the game.
+Then you have something like this...
+```csharp
+public class Example
+{
+   SignalBus signalBus;
+   public Example(Signalbus signalBus) => this.signalBus = signalBus;
+   
+   public void CheckpointReached() => signalBus.AbstractFire<SignalCheckpointReached>();
+   
+   public void CompleteLevel() => signalBus.AbstractFire<SignalLevelCompleted>();
+}
+
+public class SaveGameSystem
+{
+   public SaveGameSystem(SignalBus signalBus)
+   {
+      signalBus.Subscribe<ISignalGameSaver>(x => SaveGame());
+   }
+   
+   void SaveGame() { /*Saves the game*/ }
+}
+
+//in your installer
+Container.DeclareSignalWithInterfaces<SignalLevelCompleted>();
+Container.DeclareSignalWithInterfaces<SignalCheckpointReached>();
+
+//your signal types
+public struct SignalCheckpointReached : ISignalGameSaver{}
+public struct SignalLevelCompleted : ISignalGameSaver{}
+
+public interface ISignalGameSaver{}
+```
+
+Now your ``SaveGameSystem`` doesnt knows about CheckPoints nor Level events, and just reacts to signals that save the game.
+The main difference is in the Signal declaration and Firing
+ - ``DeclareSignalWithInterfaces`` works like ``DeclareSignal`` but it declares the interfaces too.
+ - ``AbstractFire`` is the same that ``Fire`` but it fires the interfacesjust if you have Declared the signal with interfaces 
+ otherwise it will throw an exception.
+
+Ok, let's show even more power.
+Now i create another signal for the WorldDestroyed Achievement "SignalWorldDestroyed"
+But i also want my SoundSystem to play sounds when i reach a checkpoint and/or unlock an Achievement
+So the code could look like this.
+```csharp
+public class Example
+{
+   SignalBus signalBus;
+   public Example(Signalbus signalBus) => this.signalBus = signalBus;
+   
+   public void CheckpointReached() => signalBus.AbstractFire<SignalCheckpointReached>();
+   
+   public void DestroyWorld() => signalBus.AbstractFire<SignalWorldDestroyed>();
+}
+
+public class SoundSystem
+{
+   public SoundSystem(SignalBus signalBus)
+   {
+      signalBus.Subscribe<ISignalSoundPlayer>(x => PlaySound(x.soundId));
+   }
+   
+   void PlaySound(int soundId) { /*Plays the sound with the given id*/ }
+}
+
+public class AchievementSystem
+{
+   public AchievementSystem(SignalBus signalBus)
+   {
+      signalBus.Subscribe<ISignalAchievementUnlocker>(x => UnlockAchievement(x.achievementKey));
+   }
+   
+   void UnlockAchievement(string key) { /*Unlocks the achievement with the given key*/ }
+}
+
+//in your installer
+Container.DeclareSignalWithInterfaces<SignalCheckpointReached>();
+Container.DeclareSignalWithInterfaces<SignalWorldDestroyed>();
+
+//your signal types
+public struct SignalCheckpointReached : ISignalGameSaver, ISignalSoundPlayer
+{ 
+   public int SoundId { get => 2} //or configured in a scriptable with constants instead of hardcoded
+}
+public struct SignalWorldDestroyed : ISignalAchievementUnlocker, ISignalSoundPlayer
+{
+   public int SoundId { get => 4}
+   public string AchievementKey { get => "WORLD_DESTROYED"}
+}
+
+//Your signal interfaces
+public interface ISignalGameSaver{}
+public interface ISignalSoundPlayer{ int SoundId {get;}}
+public interface ISignalAchievementUnlocker{ string AchievementKey {get;}}
+```
+
+It offers a lot of modularity and abstraction for signals,
+you fire a concrete signal telling what you did and give them functionality trough Interface implementations
 
 ## <a id="use-with-subcontainers"></a>Signals With Subcontainers
 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Internal/Binders/SignalExtensions.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Internal/Binders/SignalExtensions.cs
@@ -30,6 +30,24 @@ namespace Zenject
             return container.DeclareSignal(typeof(TSignal));
         }
 
+        //If you declare a concrete signal type with their interfaces you can do abstract Firing to get their non concrete subscriptions
+        public static DeclareSignalIdRequireHandlerAsyncTickPriorityCopyBinder DeclareSignalWithInterfaces<TSignal>(this DiContainer container)
+        {
+            Type type = typeof(TSignal);
+
+            var declaration = container.DeclareSignal(type);
+
+            //Automatic interface declaration
+            Type[] interfaces = type.GetInterfaces();
+            int numOfInterfaces = interfaces.Length;
+            for (int i = 0; i < numOfInterfaces; i++)
+            {
+                container.DeclareSignal(interfaces[i]);
+            }
+
+            return declaration;
+        }
+
         public static BindSignalIdToBinder<TSignal> BindSignal<TSignal>(this DiContainer container)
         {
             var signalBindInfo = new SignalBindingBindInfo(typeof(TSignal));

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Internal/Binders/SignalExtensions.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Internal/Binders/SignalExtensions.cs
@@ -30,14 +30,12 @@ namespace Zenject
             return container.DeclareSignal(typeof(TSignal));
         }
 
-        //If you declare a concrete signal type with their interfaces you can do abstract Firing to get their non concrete subscriptions
         public static DeclareSignalIdRequireHandlerAsyncTickPriorityCopyBinder DeclareSignalWithInterfaces<TSignal>(this DiContainer container)
         {
             Type type = typeof(TSignal);
 
             var declaration = container.DeclareSignal(type);
 
-            //Automatic interface declaration
             Type[] interfaces = type.GetInterfaces();
             int numOfInterfaces = interfaces.Length;
             for (int i = 0; i < numOfInterfaces; i++)

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -68,7 +68,7 @@ namespace Zenject
                 //To make this work you should also declare the signal's interfaces, but they are automatically declared
                 //if you do "DeclareSignalWithInterfaces<TSignal>()" in the container 
                 //Go to SignalExtensions.cs for more info
-                var declaration = GetDeclaration(interfaces[i], identifier, true);
+                declaration = GetDeclaration(interfaces[i], identifier, true);
                 declaration.Fire(signal);
             }
 		}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -56,25 +56,12 @@ namespace Zenject
 		public void AbstractFireId<TSignal>(object identifier, TSignal signal)
 		{
 			// Do this before creating the signal so that it throws if the signal was not declared
-			Type tt = typeof(TSignal);
-			var declaration = GetDeclaration(tt, identifier, true);
+			Type signalType = typeof(TSignal);
+			var declaration = GetDeclaration(signalType, identifier, true);
 			declaration.Fire(signal);
 
-            //Everything is fired like a normal signal and then this method Fires the signal with the interface types
-            //Its async because its faster and doesn't blocks the main thread when you fire signals
-            //Tested with a loop of 1 million iteration and this is the faster way of getting the interfaces fast
-			FireSignalGetDeclarationForInterfacesAsync(identifier, signal, tt);
-		}
-
-        //Fire and forget methof for the task
-		public async void FireSignalGetDeclarationForInterfacesAsync<TSignal>(object identifier, TSignal signal, Type type)
-		{
-			await Task.Run(() => FireSignalGetDeclarationForInterfacesTask(identifier, signal, type));
-		}
-        public async Task FireSignalGetDeclarationForInterfacesTask<TSignal>(object identifier, TSignal signal, Type type)
-        {
-            //The asynchronous iteration for reflection
-            Type[] interfaces = type.GetInterfaces();
+            //Everything is fired like a normal signal and then method Fires the signal with the interface types
+            Type[] interfaces = signalType.GetInterfaces();
             int numOfInterfaces = interfaces.Length;
             for (int i = 0; i < numOfInterfaces; i++)
             {
@@ -84,9 +71,7 @@ namespace Zenject
                 var declaration = GetDeclaration(interfaces[i], identifier, true);
                 declaration.Fire(signal);
             }
-        }
-
-
+		}
 
         public void LateDispose()
         {

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -50,7 +50,7 @@ namespace Zenject
         }
 
 
-        //AbstractFire Works like a normal Fire but it fires the interface types of the signal too
+        //Fires Signals with their interfaces
         public void AbstractFire<TSignal>() where TSignal : new() => AbstractFire(new TSignal());
 		public void AbstractFire<TSignal>(TSignal signal) => AbstractFireId(null, signal);
 		public void AbstractFireId<TSignal>(object identifier, TSignal signal)
@@ -60,14 +60,10 @@ namespace Zenject
 			var declaration = GetDeclaration(signalType, identifier, true);
 			declaration.Fire(signal);
 
-            //Everything is fired like a normal signal and then method Fires the signal with the interface types
             Type[] interfaces = signalType.GetInterfaces();
             int numOfInterfaces = interfaces.Length;
             for (int i = 0; i < numOfInterfaces; i++)
             {
-                //To make this work you should also declare the signal's interfaces, but they are automatically declared
-                //if you do "DeclareSignalWithInterfaces<TSignal>()" in the container 
-                //Go to SignalExtensions.cs for more info
                 declaration = GetDeclaration(interfaces[i], identifier, true);
                 declaration.Fire(signal);
             }


### PR DESCRIPTION
## Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number #90 

## What is the current behavior?

Normally you can not declare concrete interfaces
and then subscribe to their interface types
and you realice you are coupling your concrete signal types to the receivers
for example.
Lets say I have a player and i want to save the game when i finish a level 
Ok, easy I create **"signalLevelCompleted"** and then I subscribe it to my **"SaveGameSystem"**

then I also want to save when i reach a checkpoint
Again i create **"SignalCheckpointReached"**
and then I subscribe it to my **"SaveGameSystem"**

And then you realize you are coupling the types
**"signalLevelCompleted"** and **"SignalCheckpointReached"** to your **"SaveGameSystem"**

ohhh its not too good...

## What is the new behavior?

Lets give the power of the interfaces to the signals

So i have the  **SignalCheckPoint** reached
and **SignalLevelCompleted** 
Both implements **ISignalGameSaver**

My **GameSaverSystem** just Subscribes to **ISignalGameSaver** for saving the game
So when i shot any of that signals i automatically save the game

and if for example i create another signal for Achievements "**SignalAchievementCompleted**"
I just have to implement the interface to it so it saves the game automatically

It offers a lot of **modularity**, **abstractions** and **flexibility** to signals
Since you are firing a concrete signal with the type of what you are doing
And giving them functionality trough Interface implementations



## Does this introduce a breaking change?

- [ ] Yes
- [x] No, Its just an extension

## How to use
- All you have to do is "signalBus.AbstractFire" instead "signalBus.Fire"
In this way you are firing also the interfaces, and they need to be declared too
in this way "Container.DeclareSignalWithInterfaces<TSignal>()" insteas of
"Container.DeclareSignal<TSignal>()"

- other ways it will give an exception for not declaring also interfaces when doing AbstractFire

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [x] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [ ] Mono
- [x] IL2CPP
