### PR TITLE
Fix OnInstantiated callback not being called after injection in Insta…

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/Factory/FactoryFromBinderBase.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/Factory/FactoryFromBinderBase.cs
@@ -79,7 +79,7 @@ namespace Zenject
             BindingUtil.AssertInstanceDerivesFromOrEqual(instance, AllParentTypes);
 
             ProviderFunc =
-                (container) => new InstanceProvider(ContractType, instance, container);
+                (container) => new InstanceProvider(ContractType, instance, container, null);
 
             return this;
         }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/FromBinders/FromBinder.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/FromBinders/FromBinder.cs
@@ -872,7 +872,7 @@ namespace Zenject
             BindInfo.MarkAsCreationBinding = false;
             SubFinalizer = new ScopableBindingFinalizer(
                 BindInfo,
-                (container, type) => new InstanceProvider(type, instance, container));
+                (container, type) => new InstanceProvider(type, instance, container, BindInfo.InstantiatedCallback));
 
             return new ScopeConcreteIdArgConditionCopyNonLazyBinder(BindInfo);
         }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
@@ -2871,7 +2871,7 @@ namespace Zenject
             statement.SetFinalizer(
                 new ScopableBindingFinalizer(
                     bindInfo,
-                    (container, type) => new InstanceProvider(type, instance, container)));
+                    (container, type) => new InstanceProvider(type, instance, container, bindInfo.InstantiatedCallback)));
 
             return new IdScopeConcreteIdArgConditionCopyNonLazyBinder(bindInfo);
         }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Providers/InstanceProvider.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Providers/InstanceProvider.cs
@@ -10,13 +10,15 @@ namespace Zenject
         readonly object _instance;
         readonly Type _instanceType;
         readonly DiContainer _container;
+        readonly Action<InjectContext, object> _instantiateCallback;
 
         public InstanceProvider(
-            Type instanceType, object instance, DiContainer container)
+            Type instanceType, object instance, DiContainer container, Action<InjectContext, object> instantiateCallback)
         {
             _instanceType = instanceType;
             _instance = instance;
             _container = container;
+            _instantiateCallback = instantiateCallback;
         }
 
         public bool IsCached
@@ -42,7 +44,15 @@ namespace Zenject
 
             Assert.That(_instanceType.DerivesFromOrEqual(context.MemberType));
 
-            injectAction = () => _container.LazyInject(_instance);
+            injectAction = () =>
+            {
+                object instance = _container.LazyInject(_instance);
+
+                if (_instantiateCallback != null)
+                {
+                    _instantiateCallback(context, instance);
+                }
+            };
 
             buffer.Add(_instance);
         }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue  #97

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Bindings made with an Instance Provider does not account for bindInfo.InstansiatedCallback which results in OnInstantiated() callbacks never being invoked.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The callback bound with OnInstantiated() will now be invoked when binding with an InstanceProvider

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- I hacked this commit together pretty quickly (Mostly through trial and error). It's a pretty small commit, but I would assume this is the "correct" way to fix this issue.

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
