### PR TITLE
Fix AbstractFire compile error

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/Signals/Main/SignalBus.cs
@@ -65,8 +65,6 @@ namespace Zenject
 			// Do this before creating the signal so that it throws if the signal was not declared
 			Type signalType = typeof(TSignal);
             InternalFire(signalType, signal, identifier, true);
-			var declaration = GetDeclaration(signalType, identifier, true);
-			declaration.Fire(signal);
 
             Type[] interfaces = signalType.GetInterfaces();
             int numOfInterfaces = interfaces.Length;

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Signals/TestSignalsAdvanced.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/UnitTests/Editor/Signals/TestSignalsAdvanced.cs
@@ -229,6 +229,27 @@ namespace Zenject.Tests.Signals
             Assert.IsEqual(callCount, 2);
         }
 
+        [Test]
+        public void TestAbstractFireReceivedOnSubscribe()
+        {
+            Container.DeclareSignalWithInterfaces<FizzSignal>();
+            var signalBus = Container.Resolve<SignalBus>();
+
+            int callInterfaceCount = 0;
+            signalBus.Subscribe<IFizzSignal>((() => callInterfaceCount++));
+            int callConcreteCount = 0;
+            signalBus.Subscribe<FizzSignal>((() => callConcreteCount++));
+            
+            signalBus.AbstractFire<FizzSignal>();
+            Assert.IsEqual(callInterfaceCount, 1);
+            Assert.IsEqual(callConcreteCount, 1);
+        }
+
+        public interface IFizzSignal { }
+        public class FizzSignal : IFizzSignal
+        {            
+        }
+
         public class FooSignal
         {
         }


### PR DESCRIPTION


## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

-

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [ ] 2019.2
- [x] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
