### PR TITLE
Fixed CheckInstallerPrefabTypes with Unity 2018.3 and later

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -109,16 +109,12 @@ namespace Zenject
                 Assert.IsNotNull(installer, "Found null installer in Context '{0}'", name);
 
 #if UNITY_EDITOR
-#if UNITY_2019_1_OR_NEWER
-                // TODO - Is there a way to check this using GetPrefabAssetType in 2019+?
-#else
-#if UNITY_2018_3
-                Assert.That(PrefabUtility.GetPrefabAssetType(installer.gameObject) == PrefabAssetType.NotAPrefab,
+#if UNITY_2018_3_OR_NEWER
+                Assert.That(!PrefabUtility.IsPartOfPrefabAsset(installer.gameObject),
 #else
                 Assert.That(PrefabUtility.GetPrefabType(installer.gameObject) != PrefabType.Prefab,
 #endif
                     "Found prefab with name '{0}' in the Installer property of Context '{1}'.  You should use the property 'InstallerPrefabs' for this instead.", installer.name, name);
-#endif
 #endif
             }
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

Not filed

## What is the current behavior?
1. The obsolete check was used with Unity 2018.4, generating compiler warnings
2. The check used with Unity 2018.3 was generating failures for nested prefabs.
3. No check was performed for Unity 2019 or later

## What is the new behavior?
1. The compiler warning is fixed
2. I switched to use PrefabUtility.IsPartOfPrefabAsset(installer.gameObject), which is the equivalent of the old check.
3. The newly used check works fine with Unity 2019 too.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- We work with Extenject embedded in our projects, so didn't write tests for the bug about nested prefabs. Could use some help with that if you want that covered.

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [x] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
