### PR TITLE
Add DecoratableMonoKernel implementation

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 503a300139444eda80c6549ec29b3b20
+timeCreated: 1587924687

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/DelayedInitializeKernel.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/DelayedInitializeKernel.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Zenject;
+
+namespace Zenject.Tests.TestAnimationStateBehaviourInject
+{
+    public class DelayedInitializeKernel : BaseMonoKernelDecorator
+    {
+        public async override void Initialize()
+        {
+            await Task.Delay(5000);
+            DecoratedMonoKernel.Initialize();
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/DelayedInitializeKernel.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/DelayedInitializeKernel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 983f0bc44f6541bfab062ceec72231d3
+timeCreated: 1587867811

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/KernelDecoratorInstaller.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/KernelDecoratorInstaller.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using Zenject;
+
+namespace Zenject.Tests.TestAnimationStateBehaviourInject
+{
+    public class KernelDecoratorInstaller : Installer<KernelDecoratorInstaller>
+    {
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesTo<DecoratableMonoKernel>().AsCached();
+            Container.Decorate<IDecoratableMonoKernel>().With<DelayedInitializeKernel>();
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/KernelDecoratorInstaller.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/KernelDecoratorInstaller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 71d4a84946422ad49ae352537c257aed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/TestMonoKernelDecoration.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/TestMonoKernelDecoration.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using ModestTree.Util;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Zenject;
+using Zenject.Tests.TestAnimationStateBehaviourInject;
+
+namespace Zenject.Tests.Misc.TestMonoKernelDecoration
+{
+    public class TestMonoKernelDecoration : ZenjectIntegrationTestFixture
+    {
+        
+        [UnityTest]
+        public IEnumerator TestDelayedMonoKernelDecorator()
+        {
+            PreInstall();
+
+            Container.Rebind<InitializableManager>().To<InitializableManagerSpy>().AsCached();
+            KernelDecoratorInstaller.Install(Container);
+            PostInstall();
+            
+            yield return new WaitForSeconds(1.0f);
+
+            InitializableManagerSpy initializableManager = SceneContext.Container.Resolve<InitializableManager>() as InitializableManagerSpy;
+            var initializedBeforeDelay = initializableManager.IsInitialized;
+            
+            yield return new WaitForSeconds(6.0f);
+            var initializedAfterDelay = initializableManager.IsInitialized;
+
+            Assert.IsFalse(initializedBeforeDelay);
+            Assert.IsTrue(initializedAfterDelay);
+        }
+        
+        private class InitializableManagerSpy : InitializableManager
+        {
+            
+            public InitializableManagerSpy(List<IInitializable> initializables, List<ValuePair<Type, int>> priorities) : base(initializables, priorities){}
+
+            public bool IsInitialized => _hasInitialized;
+        }
+        
+        
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/TestMonoKernelDecoration.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Misc/TestMonoKernelDecoration/TestMonoKernelDecoration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 166ad9cc65d872b48badf6da39e4a31c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/InitializableManager.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/InitializableManager.cs
@@ -12,7 +12,7 @@ namespace Zenject
     {
         List<InitializableInfo> _initializables;
 
-        bool _hasInitialized;
+        protected bool _hasInitialized;
 
         [Inject]
         public InitializableManager(

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/DecoratableMonoKernel.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/DecoratableMonoKernel.cs
@@ -1,0 +1,73 @@
+﻿namespace Zenject
+{
+    public interface IDecoratableMonoKernel
+    {
+        bool ShouldInitializeOnStart();
+        void Initialize();
+        void Update();
+        void FixedUpdate();
+        void LateUpdate();
+        void Dispose();
+        void LateDispose();
+    }
+
+    public class DecoratableMonoKernel : IDecoratableMonoKernel
+    {
+        [InjectLocal] 
+        public TickableManager TickableManager { get; protected set; } = null;
+
+        [InjectLocal]
+        public InitializableManager InitializableManager { get; protected set; } = null;
+
+        [InjectLocal]
+        public DisposableManager DisposablesManager { get; protected set; } = null;
+        
+        
+        public virtual bool ShouldInitializeOnStart() => true;
+        
+        public virtual void Initialize()
+        {
+            InitializableManager.Initialize();
+        }
+
+        public void Update()
+        {
+            TickableManager.Update();
+        }
+
+        public void FixedUpdate()
+        {
+            TickableManager.FixedUpdate();
+        }
+
+        public void LateUpdate()
+        {
+            TickableManager.LateUpdate();
+        }
+
+        public void Dispose()
+        {
+            DisposablesManager.Dispose();
+        }
+
+        public void LateDispose()
+        {
+            DisposablesManager.LateDispose();
+        }
+    }
+
+    public abstract class BaseMonoKernelDecorator : IDecoratableMonoKernel
+    {
+        [Inject] 
+        protected IDecoratableMonoKernel DecoratedMonoKernel;
+
+        public virtual bool ShouldInitializeOnStart() => DecoratedMonoKernel.ShouldInitializeOnStart();
+        public virtual void Initialize() => DecoratedMonoKernel.Initialize();
+        public virtual void Update() => DecoratedMonoKernel.Update();
+        public virtual void FixedUpdate() => DecoratedMonoKernel.FixedUpdate();
+        public virtual void LateUpdate() => DecoratedMonoKernel.LateUpdate();
+        public virtual void Dispose() => DecoratedMonoKernel.Dispose();
+        public virtual void LateDispose() => DecoratedMonoKernel.LateDispose();
+    }
+    
+}

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/DecoratableMonoKernel.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/DecoratableMonoKernel.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f054684b4d0f44a1904823270ae3f137
+timeCreated: 1587868417

--- a/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/MonoKernel.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Runtime/Kernels/MonoKernel.cs
@@ -2,6 +2,7 @@
 
 using ModestTree;
 using UnityEngine;
+using UnityEngine.Analytics;
 
 namespace Zenject
 {
@@ -16,6 +17,9 @@ namespace Zenject
         [InjectLocal]
         DisposableManager _disposablesManager = null;
 
+        [InjectOptional] 
+        private IDecoratableMonoKernel decoratableMonoKernel;
+
         bool _hasInitialized;
         bool _isDestroyed;
 
@@ -26,7 +30,10 @@ namespace Zenject
 
         public virtual void Start()
         {
-            Initialize();
+            if (decoratableMonoKernel?.ShouldInitializeOnStart()??true)
+            {
+                Initialize();
+            }
         }
 
         public void Initialize()
@@ -35,7 +42,15 @@ namespace Zenject
             if (!_hasInitialized)
             {
                 _hasInitialized = true;
-                _initializableManager.Initialize();
+
+                if (decoratableMonoKernel != null)
+                {
+                    decoratableMonoKernel.Initialize();
+                }
+                else
+                {
+                    _initializableManager.Initialize();
+                }
             }
         }
 
@@ -44,7 +59,14 @@ namespace Zenject
             // Don't spam the log every frame if initialization fails and leaves it as null
             if (_tickableManager != null)
             {
-                _tickableManager.Update();
+                if (decoratableMonoKernel != null)
+                {
+                    decoratableMonoKernel.Update();
+                }
+                else
+                {
+                    _tickableManager.Update();
+                }
             }
         }
 
@@ -53,7 +75,14 @@ namespace Zenject
             // Don't spam the log every frame if initialization fails and leaves it as null
             if (_tickableManager != null)
             {
-                _tickableManager.FixedUpdate();
+                if (decoratableMonoKernel != null)
+                {
+                    decoratableMonoKernel.FixedUpdate();
+                }
+                else
+                {
+                    _tickableManager.FixedUpdate();
+                }
             }
         }
 
@@ -62,7 +91,14 @@ namespace Zenject
             // Don't spam the log every frame if initialization fails and leaves it as null
             if (_tickableManager != null)
             {
-                _tickableManager.LateUpdate();
+                if (decoratableMonoKernel != null)
+                {
+                    decoratableMonoKernel.LateUpdate();
+                }
+                else
+                {
+                    _tickableManager.LateUpdate();
+                }
             }
         }
 
@@ -74,8 +110,16 @@ namespace Zenject
                 Assert.That(!_isDestroyed);
                 _isDestroyed = true;
 
-                _disposablesManager.Dispose();
-                _disposablesManager.LateDispose();
+                if (decoratableMonoKernel != null)
+                {
+                    decoratableMonoKernel.Dispose();
+                    decoratableMonoKernel.LateDispose();
+                }
+                else
+                {
+                    _disposablesManager.Dispose();
+                    _disposablesManager.LateDispose();
+                }
             }
         }
     }


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number
<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: https://github.com/svermeulen/Extenject/issues/119

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Currently MonoKernel calls related methods in InitializableManager, TickableManager and DisposableManager directly with Unity lifecycle methods like Start, Update, OnDestroy

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- MonoKernel relegates these calls to DecoratableMonoKernel if the optional binding exists. This class is easier to decorate and allows implementer to change the default behavior without effecting script execution order of different MonoKernels (Project, Scene, DefaultGameObject)

## Does this introduce a breaking change?

- [ ] Yes
- [x ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-
Since MonoKernel is a MonoBehavior it is not possible manipulate script execution via directly decorating it. If you try to do so Unity will still call Start method based on its own lifecycle skipping the decorator. Therefore this decoration implementation is unortodox in terms of textbook decoration pattern.

In essence instead of decorating mono kernel, we introduce DecoratableMonoKernel as an optional dependency. MonoKernel works as normal unless this dependency exists, in which case relegates the calls related calls to be handled by DecoratableMonoKernel. DecoratableMonoKernel is a pure C# class so it can be decorated freely.

For ease of use a BaseMonoKernelDecoratorClass is also provided which by default wraps all calls with a virtual method that calls original wrapped class. So implementer can override only the necessary methods.

Example test case is provided in integration test where InitializationManager is delayed with async call.

No updates in documentation is made as of now, as I am not sure where it should be included (or whether it should be included at all)

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
