### PR TITLE
Remap key bindings - Closes #133

### DIFF
--- a/README.md
+++ b/README.md
@@ -1323,7 +1323,7 @@ This works ok for small projects, but as the complexity of your project grows it
 
 You can do this in Zenject out-of-the-box by executing the menu item `Edit -> Zenject -> Validate Current Scene` or simply hitting `SHIFT+ALT+V` with the scenes open that you want to validate.  This will execute all installers for the current scene, with the result being a fully bound container.   It will then iterate through the object graphs and verify that all bindings can be found (without actually instantiating any of them).  In other words, it executes a 'dry run' of the normal startup procedure.  Under the hood, this works by storing dummy objects in the container in place of actually instantiating your classes.
 
-Alternatively, you can execute the menu item `Edit -> Zenject -> Validate Then Run` or simply hitting `CTRL+SHIFT+R`.  This will validate the scenes you have open and then if validation succeeds, it will start play mode.  Validation is usually pretty fast so this can be a good alternative to always just hitting play, especially if your game has a costly startup time.
+Alternatively, you can execute the menu item `Edit -> Zenject -> Validate Then Run` or simply hitting `CTRL+ALT+R`.  This will validate the scenes you have open and then if validation succeeds, it will start play mode.  Validation is usually pretty fast so this can be a good alternative to always just hitting play, especially if your game has a costly startup time.
 
 Note that this will also include factories and memory pools, which is especially helpful because those errors might not be caught until sometime after startup.
 

--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/ZenMenuItems.cs
@@ -10,15 +10,13 @@ namespace Zenject.Internal
 {
     public static class ZenMenuItems
     {
-        // NOTE: We use shift+alt+v instead of control+shift+v because control+shift+v conflicts
-        // with a vuforia shortcut
         [MenuItem("Edit/Zenject/Validate Current Scenes #&v")]
         public static void ValidateCurrentScene()
         {
             ValidateCurrentSceneInternal();
         }
 
-        [MenuItem("Edit/Zenject/Validate Then Run #%r")]
+        [MenuItem("Edit/Zenject/Validate Then Run #&r")]
         public static void ValidateCurrentSceneThenRun()
         {
             if (ValidateCurrentSceneInternal())


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: #133 

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- The Zenject "Validate Then Run" menu has a conflict with another Unity key mapping.
- Shift-Command-R

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Shift -Option(Alt)-R

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [x] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [ ] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
