### PR TITLE
Parent game objects

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fc25b56d0d0d34d87bf63f6e8cf23e1b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildController.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildController.cs
@@ -1,0 +1,17 @@
+using ModestTree;
+
+namespace Zenject.Tests.GameObjectAsParentContract
+{
+    public class ChildController
+    {
+        [Inject] private SessionController _sessionController;
+
+        [Inject]
+        public void Construct()
+        {
+            Assert.That(_sessionController.IsInitialized);
+            
+            Log.Trace("Initialized successfully");
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildController.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 376ba4810a1d49efa1fef2b356e6e982
+timeCreated: 1594043039

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildInstaller.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildInstaller.cs
@@ -1,0 +1,10 @@
+namespace Zenject.Tests.GameObjectAsParentContract
+{
+    public class ChildInstaller : MonoInstaller<ChildInstaller>
+    {
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesAndSelfTo<ChildController>().AsSingle().NonLazy();
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildInstaller.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ef5b448cdef147afb64431497a3e0558
+timeCreated: 1594043006

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildScene.unity
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildScene.unity
@@ -1,0 +1,200 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.3731193, g: 0.38073996, b: 0.35872698, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 10
+    m_AtlasSize: 512
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 256
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1045283491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1045283493}
+  - component: {fileID: 1045283492}
+  - component: {fileID: 1045283494}
+  m_Layer: 0
+  m_Name: ChildContext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1045283492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045283491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89715ad69b973a14899afa2c6730b30b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scriptableObjectInstallers: []
+  _monoInstallers:
+  - {fileID: 1045283494}
+  _installerPrefabs: []
+  _autoRun: 1
+  OnPreInstall:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPostInstall:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPreResolve:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPostResolve:
+    m_PersistentCalls:
+      m_Calls: []
+  _parentNewObjectsUnderSceneContext: 0
+  _contractNames: []
+  _parentContractNames:
+  - SessionContext
+--- !u!4 &1045283493
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045283491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1045283494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1045283491}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ef5b448cdef147afb64431497a3e0558, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildScene.unity.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/ChildScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dac27dba164047258ce9a537f7499049
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainInstaller.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainInstaller.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Zenject.Tests.GameObjectAsParentContract
+{
+    public class MainInstaller : MonoInstaller<MainInstaller>
+    {
+        [SerializeField] private GameObjectContext sessionContext;
+        
+        public override void InstallBindings()
+        {
+            sessionContext.Install(Container);
+
+            SceneManager.LoadScene("ChildScene", LoadSceneMode.Additive);
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainInstaller.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6580db70f48541b0a320b8aea49a9862
+timeCreated: 1594042849

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainScene.unity
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainScene.unity
@@ -1,0 +1,440 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 170076734}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 10
+    m_AtlasSize: 512
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 256
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &170076733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 170076735}
+  - component: {fileID: 170076734}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &170076734
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 170076733}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.802082
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &170076735
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 170076733}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &534669902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 534669905}
+  - component: {fileID: 534669904}
+  - component: {fileID: 534669903}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &534669903
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 534669902}
+  m_Enabled: 1
+--- !u!20 &534669904
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 534669902}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &534669905
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 534669902}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1883431034
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1883431037}
+  - component: {fileID: 1883431035}
+  - component: {fileID: 1883431036}
+  m_Layer: 0
+  m_Name: SessionContext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1883431035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883431034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08eca9f7688a0a24685b89133b020c8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scriptableObjectInstallers: []
+  _monoInstallers:
+  - {fileID: 1883431036}
+  _installerPrefabs: []
+  _autoRun: 1
+  _contractNames:
+  - SessionContext
+  _kernel: {fileID: 0}
+--- !u!114 &1883431036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883431034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e36cd82282ec459ba94ac79e0a117c65, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1883431037
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1883431034}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2100470244}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2100470242
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100470244}
+  - component: {fileID: 2100470245}
+  - component: {fileID: 2100470247}
+  m_Layer: 0
+  m_Name: MainContext
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2100470244
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100470242}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1883431037}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2100470245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100470242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89715ad69b973a14899afa2c6730b30b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scriptableObjectInstallers: []
+  _monoInstallers:
+  - {fileID: 2100470247}
+  _installerPrefabs: []
+  _autoRun: 1
+  OnPreInstall:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPostInstall:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPreResolve:
+    m_PersistentCalls:
+      m_Calls: []
+  OnPostResolve:
+    m_PersistentCalls:
+      m_Calls: []
+  _parentNewObjectsUnderSceneContext: 0
+  _contractNames: []
+  _parentContractNames: []
+--- !u!114 &2100470247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100470242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6580db70f48541b0a320b8aea49a9862, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sessionContext: {fileID: 1883431035}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainScene.unity.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/MainScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9714185a24154aed90e41ded9c2b89ce
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/Resources.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bbd09cf1b91a84e49af69df75efd13f0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/Resources/TestGameObjectAsParentContract.asset
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/Resources/TestGameObjectAsParentContract.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b634c456740a0e42928511e3f2ada75, type: 3}
+  m_Name: TestGameObjectAsParentContract
+  m_EditorClassIdentifier: 
+  Scene: {fileID: 102900000, guid: 1f4260ca3498345ce9ff7a239ef30b62, type: 3}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/Resources/TestGameObjectAsParentContract.asset.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/Resources/TestGameObjectAsParentContract.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: fbb1ecf065d954f27ace0c74e8b9ddc9
+timeCreated: 1527239664
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionController.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionController.cs
@@ -1,0 +1,13 @@
+namespace Zenject.Tests.GameObjectAsParentContract
+{
+    public class SessionController
+    {
+        public bool IsInitialized { get; private set; }
+        
+        [Inject]
+        public void Construct()
+        {
+            IsInitialized = true;
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionController.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 58a436de9671410baeb92c18ef3adf97
+timeCreated: 1594034693

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionInstaller.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionInstaller.cs
@@ -1,0 +1,10 @@
+namespace Zenject.Tests.GameObjectAsParentContract
+{
+    public class SessionInstaller : MonoInstaller<MainInstaller>
+    {
+        public override void InstallBindings()
+        {
+            Container.BindInterfacesAndSelfTo<SessionController>().AsSingle();
+        }
+    }
+}

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionInstaller.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/SceneContractTests/GameObjectAsParentContract/SessionInstaller.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e36cd82282ec459ba94ac79e0a117c65
+timeCreated: 1594042276

--- a/UnityProject/Assets/Plugins/Zenject/Source/Editor/Editors/GameObjectContextEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Editor/Editors/GameObjectContextEditor.cs
@@ -8,11 +8,15 @@ namespace Zenject
     [NoReflectionBaking]
     public class GameObjectContextEditor : RunnableContextEditor
     {
+        SerializedProperty _contractNamesProperty;
+
         SerializedProperty _kernel;
 
         public override void OnEnable()
         {
             base.OnEnable();
+
+            _contractNamesProperty = serializedObject.FindProperty("_contractNames");
 
             _kernel = serializedObject.FindProperty("_kernel");
         }
@@ -20,6 +24,8 @@ namespace Zenject
         protected override void OnGui()
         {
             base.OnGui();
+
+            EditorGUILayout.PropertyField(_contractNamesProperty, true);
 
             EditorGUILayout.PropertyField(_kernel);
         }

--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/GameObjectContext.cs
@@ -18,6 +18,10 @@ namespace Zenject
         public event Action PreResolve;
         public event Action PostResolve;
 
+        [Tooltip("Optional contract names for this GameObjectContext, allowing contexts in subsequently loaded scenes to depend on it and be parented to it")]
+        [SerializeField]
+        List<string> _contractNames = new List<string>();
+
         [SerializeField]
         [Tooltip("Note that this field is optional and can be ignored in most cases.  This is really only needed if you want to control the 'Script Execution Order' of your subcontainer.  In this case, define a new class that derives from MonoKernel, add it to this game object, then drag it into this field.  Then you can set a value for 'Script Execution Order' for this new class and this will control when all ITickable/IInitializable classes bound within this subcontainer get called.")]
         [FormerlySerializedAs("_facade")]
@@ -39,6 +43,8 @@ namespace Zenject
         {
             return new[] { gameObject };
         }
+
+        public IEnumerable<string> ContractNames => _contractNames;
 
         [Inject]
         public void Construct(


### PR DESCRIPTION
## Motivation

In bigger projects it may be convenient to use `GameObjectContext` as a parent for `SceneContext`.

Consider case where you have some non-standard context that is recreated every time player switches accounts / characters. The best approach would be to use scene contexts and their contracts functionality. However in some legacy projects it can be pretty hard and time consuming to achieve this (e.g. because of the usage of `LoadSceneMode.Single`). Switching to `LoadSceneMode.Additive` may expose many issues connected with scene unloading order.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Currently it's not possible to use GameObjectContext as parent for SceneContext.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `GameObjectContext` has additional field named `ContractNames` which is used within the initialisation of `SceneContext`.
- Introduced field is used as a fallback value - when `SceneContext` cannot find the parent `SceneContext` for given `ParentContractName`, it searches for matching `GameObjectContext`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- There's `GameObjectAsParentContract` test added to the Integration Tests section.

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [x] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [x] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
