### PR TITLE
Fix assert hit during OnInstantiated validation

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/InstantiateCallbackConditionCopyNonLazyBinder.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/InstantiateCallbackConditionCopyNonLazyBinder.cs
@@ -26,10 +26,22 @@ namespace Zenject
 
             BindInfo.InstantiatedCallback = (ctx, obj) =>
             {
-                Assert.That(obj == null || obj is T,
-                    "Invalid generic argument to OnInstantiated! {0} must be type {1}", obj.GetType(), typeof(T));
+                if (obj is ValidationMarker)
+                {
+                    Assert.That(ctx.Container.IsValidating);
 
-                callback(ctx, (T)obj);
+                    ValidationMarker marker = obj as ValidationMarker;
+
+                    Assert.That(marker.MarkedType.DerivesFromOrEqual<T>(),
+                        "Invalid generic argument to OnInstantiated! {0} must be type {1}", marker.MarkedType, typeof(T));
+                }
+                else
+                {
+                    Assert.That(obj == null || obj is T,
+                        "Invalid generic argument to OnInstantiated! {0} must be type {1}", obj.GetType(), typeof(T));
+
+                    callback(ctx, (T)obj);
+                }
             };
             return this;
         }


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Currently `OnInstantiated` causes an assert hit during validation, but is completely fine during Play Mode.

Code used to test the issue:
```cs
using UnityEngine;
using Zenject;

public class TestInstaller : MonoInstaller
{
    public override void InstallBindings()
    {
        // Gives the following exception on 'Validate Current Scenes', but OnFooInstantiated is called correctly in play mode
        // ZenjectException: Assert hit! Invalid generic argument to OnInstantiated! ValidationMarker must be type Foo
        Container.Bind<Foo>().AsSingle().OnInstantiated<Foo>(OnFooInstantiated).NonLazy();
    }

    private void OnFooInstantiated(InjectContext ctx, Foo x)
    {
        Debug.Log("Foo instantiated!");
        Debug.Log(x);
    }
}

public class Foo { }
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `OnInstantiated` now checks if the object passed in is a `ValidationMarker` and validates it accordingly in order to fix the issue above.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- None

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [X] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [X] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
