### PR TITLE
Use DerivesFromOrEqual instead of DerivesFrom for Context in resolve-during-install warning checks

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Main/DiContainer.cs
@@ -838,7 +838,7 @@ namespace Zenject
             }
 
 #if UNITY_EDITOR
-            if (context.MemberType.DerivesFrom<Context>())
+            if (context.MemberType.DerivesFromOrEqual<Context>())
             {
                 // This happens when getting default transform parent so ok
                 return;


### PR DESCRIPTION
Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No new compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: #194 

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Under certain circumstances, using a method that uses `Container.Resolve<Context>()` (e.g. `FromComponentOnRoot`) will cause an invalid warning. The following test demonstrates the issue:

```cs
public class ResolveWarningTest : ZenjectIntegrationTestFixture
{
	class TestFacade
	{
	}

	class TestInstaller : Installer<TestInstaller>
	{
		[Inject] private Transform transform;

		public override void InstallBindings()
		{
		}
	}

	[Test]
	public void FromComponentOnRoot_CausesWarning()
	{
		this.PreInstall();
		this.Container
			.Bind<TestFacade>()
			.FromSubContainerResolve()
			.ByNewGameObjectMethod(subContainer =>
			{
				subContainer.Bind<TestFacade>().AsSingle();
				subContainer.Bind<Transform>().FromComponentOnRoot();
				TestInstaller.Install(subContainer);
			})
			.AsSingle()
			.NonLazy();
		this.PostInstall();
	}
}
```

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- No warning is produced in scenarios like this

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- Since this only affects warning output, I didn't do any extensive testing on this (should be safe)
- Should a test like this be added to the test suite? Looking at the contribution guidelines, I feel like it's not in line with the general testing principles, and I couldn't easily find a category for it.

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [x] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
