### PR TITLE
Fix WithArguments when used with IFactory bindings including Components

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Factories/TestBindFactoryOne/TestBindFactoryOneWithArguments.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Factories/TestBindFactoryOne/TestBindFactoryOneWithArguments.cs
@@ -1,0 +1,163 @@
+using System.Collections;
+using ModestTree;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Zenject.Tests.Factories.BindFactoryOne;
+
+namespace Zenject.Tests.Factories
+{
+    public class TestBindFactoryOneWithArguments : ZenjectIntegrationTestFixture
+    {
+        private const string ArgumentValue = "asdf";
+
+        GameObject FooPrefab
+        {
+            get
+            {
+                return FixtureUtil.GetPrefab("TestBindFactoryOne/Foo");
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator TestFromNewComponentOnNewGameObjectSelf()
+        {
+            PreInstall();
+            Container.BindIFactory<Foo>()
+                .FromNewComponentOnNewGameObject()
+                .WithArguments(ArgumentValue);
+
+            AddFactoryUser<Foo>();
+
+            PostInstall();
+
+            FixtureUtil.AssertComponentCount<Foo>(1);
+            FixtureUtil.AssertNumGameObjects(1);
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator TestFromNewComponentOnNewGameObjectConcrete()
+        {
+            PreInstall();
+            Container.BindIFactory<IFoo>()
+                .To<Foo>()
+                .FromNewComponentOnNewGameObject()
+                .WithArguments(ArgumentValue);
+
+            AddFactoryUser<IFoo>();
+
+            PostInstall();
+
+            FixtureUtil.AssertComponentCount<Foo>(1);
+            FixtureUtil.AssertNumGameObjects(1);
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator TestFromComponentInNewPrefabSelf()
+        {
+            PreInstall();
+            Container.BindIFactory<Foo>()
+                .FromComponentInNewPrefab(FooPrefab)
+                .WithGameObjectName("asdf")
+                .WithArguments(ArgumentValue);
+
+            AddFactoryUser<Foo>();
+
+            PostInstall();
+
+            FixtureUtil.AssertComponentCount<Foo>(1);
+            FixtureUtil.AssertNumGameObjects(1);
+            FixtureUtil.AssertNumGameObjectsWithName("asdf", 1);
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator TestFromComponentInNewPrefabConcrete()
+        {
+            PreInstall();
+            Container.BindIFactory<IFoo>()
+                .To<Foo>()
+                .FromComponentInNewPrefab(FooPrefab)
+                .WithGameObjectName("asdf")
+                .WithArguments(ArgumentValue);
+
+            AddFactoryUser<IFoo>();
+
+            PostInstall();
+
+            FixtureUtil.AssertComponentCount<Foo>(1);
+            FixtureUtil.AssertNumGameObjects(1);
+            FixtureUtil.AssertNumGameObjectsWithName("asdf", 1);
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator TestFromComponentInNewPrefabResourceSelf()
+        {
+            PreInstall();
+            Container.BindIFactory<Foo>()
+                .FromComponentInNewPrefabResource("TestBindFactoryOne/Foo")
+                .WithGameObjectName("asdf")
+                .WithArguments(ArgumentValue);
+
+            AddFactoryUser<Foo>();
+
+            PostInstall();
+
+            FixtureUtil.AssertComponentCount<Foo>(1);
+            FixtureUtil.AssertNumGameObjects(1);
+            FixtureUtil.AssertNumGameObjectsWithName("asdf", 1);
+            yield break;
+        }
+
+        [UnityTest]
+        public IEnumerator TestFromComponentInNewPrefabResourceConcrete()
+        {
+            PreInstall();
+            Container.BindIFactory<IFoo>().To<Foo>()
+                .FromComponentInNewPrefabResource("TestBindFactoryOne/Foo")
+                .WithGameObjectName("asdf")
+                .WithArguments(ArgumentValue);
+
+            AddFactoryUser<IFoo>();
+
+            PostInstall();
+
+            FixtureUtil.AssertComponentCount<Foo>(1);
+            FixtureUtil.AssertNumGameObjects(1);
+            FixtureUtil.AssertNumGameObjectsWithName("asdf", 1);
+            yield break;
+        }
+
+        // Note that unlike the TestBindFactory tests, WithArguments still doesn't work nicely with subcontainers...
+
+        void AddFactoryUser<TValue>()
+            where TValue : IFoo
+        {
+            Container.Bind<IInitializable>()
+                .To<FooFactoryTester<TValue>>().AsSingle();
+
+            Container.BindExecutionOrder<FooFactoryTester<TValue>>(-100);
+        }
+
+        public class FooFactoryTester<TValue> : IInitializable
+            where TValue : IFoo
+        {
+            readonly IFactory<TValue> _factory;
+
+            public FooFactoryTester(IFactory<TValue> factory)
+            {
+                _factory = factory;
+            }
+
+            public void Initialize()
+            {
+                Assert.IsEqual(_factory.Create().Value, ArgumentValue);
+
+                Log.Info("Factory created foo successfully");
+            }
+        }
+    }
+}
+

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Factories/TestBindFactoryOne/TestBindFactoryOneWithArguments.cs.meta
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/IntegrationTests/Tests/Factories/TestBindFactoryOne/TestBindFactoryOneWithArguments.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 94b7f15ee7704375a72da83287e0a7b1
+timeCreated: 1604660417

--- a/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/Factory/FactoryFromBinderBase.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Binding/Binders/Factory/FactoryFromBinderBase.cs
@@ -147,7 +147,7 @@ namespace Zenject
             ProviderFunc =
                 (container) => new AddToExistingGameObjectComponentProvider(
                     gameObject, container, ContractType,
-                    new List<TypeValuePair>(), BindInfo.ConcreteIdentifier, BindInfo.InstantiatedCallback);
+                    BindInfo.Arguments, BindInfo.ConcreteIdentifier, BindInfo.InstantiatedCallback);
 
             return this;
         }
@@ -161,7 +161,7 @@ namespace Zenject
             ProviderFunc =
                 (container) => new AddToExistingGameObjectComponentProviderGetter(
                     gameObjectGetter, container, ContractType,
-                    new List<TypeValuePair>(), BindInfo.ConcreteIdentifier, BindInfo.InstantiatedCallback);
+                    BindInfo.Arguments, BindInfo.ConcreteIdentifier, BindInfo.InstantiatedCallback);
 
             return this;
         }
@@ -176,7 +176,7 @@ namespace Zenject
             ProviderFunc =
                 (container) => new AddToNewGameObjectComponentProvider(
                     container, ContractType,
-                    new List<TypeValuePair>(), gameObjectInfo, BindInfo.ConcreteIdentifier, BindInfo.InstantiatedCallback);
+                    BindInfo.Arguments, gameObjectInfo, BindInfo.ConcreteIdentifier, BindInfo.InstantiatedCallback);
 
             return new NameTransformScopeConcreteIdArgConditionCopyNonLazyBinder(BindInfo, gameObjectInfo);
         }
@@ -194,7 +194,7 @@ namespace Zenject
                     ContractType,
                     new PrefabInstantiator(
                         container, gameObjectInfo,
-                        ContractType, new [] { ContractType }, new List<TypeValuePair>(),
+                        ContractType, new [] { ContractType }, BindInfo.Arguments,
                         new PrefabProvider(prefab), BindInfo.InstantiatedCallback));
 
             return new NameTransformScopeConcreteIdArgConditionCopyNonLazyBinder(BindInfo, gameObjectInfo);
@@ -212,7 +212,7 @@ namespace Zenject
                     ContractType,
                     new PrefabInstantiator(
                         container, gameObjectInfo,
-                        ContractType, new [] { ContractType }, new List<TypeValuePair>(),
+                        ContractType, new [] { ContractType }, BindInfo.Arguments,
                         new PrefabProvider(prefab),
                         BindInfo.InstantiatedCallback), true);
 
@@ -231,7 +231,7 @@ namespace Zenject
                     ContractType,
                     new PrefabInstantiator(
                         container, gameObjectInfo,
-                        ContractType, new [] { ContractType }, new List<TypeValuePair>(),
+                        ContractType, new [] { ContractType }, BindInfo.Arguments,
                         new PrefabProviderResource(resourcePath), BindInfo.InstantiatedCallback), true);
 
             return new NameTransformScopeConcreteIdArgConditionCopyNonLazyBinder(BindInfo, gameObjectInfo);
@@ -250,7 +250,7 @@ namespace Zenject
                     ContractType,
                     new PrefabInstantiator(
                         container, gameObjectInfo,
-                        ContractType, new [] { ContractType }, new List<TypeValuePair>(),
+                        ContractType, new [] { ContractType }, BindInfo.Arguments,
                         new PrefabProviderResource(resourcePath),
                         BindInfo.InstantiatedCallback));
 
@@ -264,7 +264,7 @@ namespace Zenject
 
             ProviderFunc =
                 (container) => new ScriptableObjectResourceProvider(
-                    resourcePath, ContractType, container, new List<TypeValuePair>(),
+                    resourcePath, ContractType, container, BindInfo.Arguments,
                     true, null, BindInfo.InstantiatedCallback);
 
             return this;
@@ -277,7 +277,7 @@ namespace Zenject
 
             ProviderFunc =
                 (container) => new ScriptableObjectResourceProvider(
-                    resourcePath, ContractType, container, new List<TypeValuePair>(),
+                    resourcePath, ContractType, container, BindInfo.Arguments,
                     false, null, BindInfo.InstantiatedCallback);
 
             return this;


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: #196

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Depends on the definition of "breaking":
Some unnecessary `WithArguments` use which was previously valid, might now produce errors about unused injected values. However, this is very unlikely to be a major issue for anyone, and points out actual problems (values being unused) in any case.

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- This fix has been in use in Yousician for a long time already without issues, only now took the time to prepare a PR out of it.

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [x] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
