### PR TITLE
Symbols Update 

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
@@ -93,7 +93,7 @@ namespace Zenject.ReflectionBaking
             {
                 var writerParams = new WriterParameters()
                 {
-                    // Required for other tools which using Mono.Cecil for IL mofification
+                    // Required for other tools which using Mono.Cecil for IL modification
                     WriteSymbols = true
                 };
 

--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Unity/ReflectionBakingBuildObserver.cs
@@ -93,8 +93,8 @@ namespace Zenject.ReflectionBaking
             {
                 var writerParams = new WriterParameters()
                 {
-                    // Is this necessary?
-                    //WriteSymbols = true
+                    // Required for other tools which using Mono.Cecil for IL mofification
+                    WriteSymbols = true
                 };
 
                 module.Write(assemblyFullPath, writerParams);


### PR DESCRIPTION
Enabled symbol update after reflection baking for support tool like Obfuscator

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number
Issue Number: https://github.com/svermeulen/Extenject/issues/201

## What is the current behavior?
There is no way to use other tools modifying IL due to the fact that symbols are not updated. 
It leads to SymbolsNotMatchingException in other tools.

## What is the new behavior?
After bake we update symbols.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
-

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [x] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [x] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
