### PR TITLE
Add support bool and float in reflection baking

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Common/ReflectionBakingModuleEditor.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/ReflectionBaking/Common/ReflectionBakingModuleEditor.cs
@@ -634,6 +634,17 @@ namespace Zenject.ReflectionBaking
                 instructions.Add(Instruction.Create(OpCodes.Ldc_I4, (int)identifier));
                 instructions.Add(Instruction.Create(OpCodes.Box, _module.Import(identifier.GetType())));
             }
+            else if (identifier is float)
+            {
+                instructions.Add(Instruction.Create(OpCodes.Ldc_R4, (float)identifier));
+                instructions.Add(Instruction.Create(OpCodes.Box, _module.Import(typeof(float))));
+            }
+            else if (identifier is bool)
+            {
+
+                instructions.Add(Instruction.Create(OpCodes.Ldc_I4, (bool)identifier ? 1 : 0));
+                instructions.Add(Instruction.Create(OpCodes.Box, _module.Import(typeof(bool))));
+            }
             else
             {
                 throw Assert.CreateException(


### PR DESCRIPTION
Fix this exception for bool and float
ZenjectException: Cannot process values with type  currently.  Feel free to add support for this and submit a pull request to github.

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: N/A

*Create or search an issue here: [Extenject/Issues](https://github.com/svermeulen/Extenject/issues)*

## What is the current behavior?
In some cases cannot use float or bool when using reflection backing

-

## What is the new behavior?
Now you can use float and bool when using reflection backing

-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
-

On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [x] 2020.3
- [x] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [x] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
