### PR TITLE
Also keep any Addressable Resource manager on Context Clean

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/ZenjectTestUtil.cs
+++ b/UnityProject/Assets/Plugins/Zenject/OptionalExtras/TestFramework/ZenjectTestUtil.cs
@@ -7,6 +7,11 @@ namespace Zenject.Internal
     public static class ZenjectTestUtil
     {
         public const string UnitTestRunnerGameObjectName = "Code-based tests runner";
+         /// <summary>
+        /// Addressable resource manager
+        /// </summary>
+        public const string ResourceManagerCallbacks     = "ResourceManagerCallbacks";
+
 
         public static void DestroyEverythingExceptTestRunner(bool immediate)
         {
@@ -31,7 +36,8 @@ namespace Zenject.Internal
 
                 foreach (var rootObj in dontDestroyOnLoadRoots)
                 {
-                    if (rootObj.name != UnitTestRunnerGameObjectName)
+                    if (rootObj.name != UnitTestRunnerGameObjectName && 
+                        rootObj.name != ResourceManagerCallbacks)
                     {
                         if (immediate)
                         {


### PR DESCRIPTION
As this is a Unity Package I think it should be added here (although in the long run there should be a way to specify additional files to keep depending on packages/own services). 

I pulled my hair out on this one. My tests where basically just hanging in the void because async operations where not finishing anymore due to this GO suppression.

Thank you for sending a pull request! Please make sure you read the [contribution guidelines](https://github.com/svermeulen/Extenject/blob/master/CONTRIBUTING.md)

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


On which Unity version has this been tested?
--------------------------------------------
- [ ] 2020.4 LTS
- [ ] 2020.3
- [ ] 2020.2
- [ ] 2020.1
- [x] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

