### PR TITLE
Replaced Resources.FindObjectsOfTypeAll by FindObjectsOfType

### DIFF
--- a/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
+++ b/UnityProject/Assets/Plugins/Zenject/Source/Install/Contexts/Context.cs
@@ -235,12 +235,14 @@ namespace Zenject
                 }
             }
 
-            // We'd prefer to use GameObject.FindObjectsOfType<ZenjectBinding>() here
-            // instead but that doesn't find inactive gameobjects
             // TODO: Consider changing this
             // Maybe ZenjectBinding could add itself to a registry class on Awake/OnEnable
             // then we could avoid calling the slow Resources.FindObjectsOfTypeAll here
+#if UNITY_2020_1_OR_NEWER
+            foreach (var binding in FindObjectsOfType<ZenjectBinding>(true))
+#else
             foreach (var binding in Resources.FindObjectsOfTypeAll<ZenjectBinding>())
+#endif
             {
                 if (binding == null)
                 {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] No compiler errors or warnings

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## Issue Number

<!-- Referencing an issue makes the creation of CHANGELOGS for new releases much easier -->
Issue Number: 262

https://github.com/modesttree/Zenject/issues/262

## What is the current behavior?

ZenjectBinding are loaded using Resources.FindObjectsOfTypeAll<ZenjectBinding>()

## What is the new behavior?

As of Unity version 2021.1, it is possible to use FindObjectsOfType<ZenjectBinding>(true) to also find inactive objects in the hierarchy
This avoid to search additional data we're not interested in

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

On which Unity version has this been tested?
--------------------------------------------
- [x] 2021.2
- [x] 2020.3 LTS
- [ ] 2020.2
- [ ] 2020.1
- [ ] 2019.4 LTS
- [ ] 2019.3
- [ ] 2019.2
- [ ] 2019.1
- [ ] 2018.4 LTS

**Scripting backend:**
- [x] Mono
- [ ] IL2CPP

> Note: Every pull request is tested on the Continuous Integration (CI) system to confirm that it works in Unity.
>
> Ideally, the pull request will pass ("be green"). This means that all tests pass and there are no errors. However, it is not uncommon for the CI infrastructure itself to fail on specific platforms or for so-called "flaky" tests to fail ("be red").  Each CI failure must be manually inspected to determine the cause.
>
> CI starts automatically when you open a pull request, but only Releasers/Collaborators can restart a CI run. If you believe CI is giving a false negative, ask a Releaser to restart the tests.
